### PR TITLE
Support rails 4.1

### DIFF
--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -13,7 +13,7 @@ module ActsAsParanoid
         result = belongs_to_without_deleted(target, options)
 
         if with_deleted
-          result.options[:with_deleted] = with_deleted
+          result[:with_deleted] = with_deleted
           unless method_defined? "#{target}_with_unscoped"
             class_eval <<-RUBY, __FILE__, __LINE__
               def #{target}_with_unscoped(*args)

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -74,7 +74,7 @@ module ActsAsParanoid
     protected
 
       def without_paranoid_default_scope
-        scope = self.__send__(paranoid_scoped_method).with_default_scope
+        scope = self.all.unscoped
         scope.where_values.delete(paranoid_default_scope_sql)
 
         scope

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -396,8 +396,6 @@ end
 class ParanoidForest < ActiveRecord::Base
   acts_as_paranoid
 
-  # HACK: scope throws an error on 1.8.7 because the logger isn't initialized (see https://github.com/Casecommons/pg_search/issues/26)
-  require "active_support/core_ext/logger.rb"
   ActiveRecord::Base.logger = Logger.new(StringIO.new)
 
   scope :rainforest, where(:rainforest => true)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -398,7 +398,7 @@ class ParanoidForest < ActiveRecord::Base
 
   ActiveRecord::Base.logger = Logger.new(StringIO.new)
 
-  scope :rainforest, where(:rainforest => true)
+  scope :rainforest, -> { where(:rainforest => true) }
 
   has_many :paranoid_trees, :dependent => :destroy
 end
@@ -411,5 +411,5 @@ end
 
 class ParanoidHuman < ActiveRecord::Base
   acts_as_paranoid
-  default_scope where('gender = ?', 'male')
+  default_scope { where('gender = ?', 'male') }
 end


### PR DESCRIPTION
fix this error

``` sh
/home/travis/.rvm/rubies/ruby-1.9.3-p551/bin/ruby -I"lib:test" -I"/home/travis/.rvm/gems/ruby-1.9.3-p551/gems/rake-10.4.2/lib" "/home/travis/.rvm/gems/ruby-1.9.3-p551/gems/rake-10.4.2/lib/rake/rake_test_loader.rb" "test/test_*.rb" 
/home/travis/build/drecom/rails3_acts_as_paranoid/lib/acts_as_paranoid/associations.rb:16:in `belongs_to_with_deleted': undefined method `options' for #<Hash:0x0000000207cc20> (NoMethodError)
    from /home/travis/build/drecom/rails3_acts_as_paranoid/test/test_helper.rb:210:in `<class:HasOneNotParanoid>'
    from /home/travis/build/drecom/rails3_acts_as_paranoid/test/test_helper.rb:209:in `<top (required)>'
    from /home/travis/build/drecom/rails3_acts_as_paranoid/test/test_associations.rb:1:in `require'
    from /home/travis/build/drecom/rails3_acts_as_paranoid/test/test_associations.rb:1:in `<top (required)>'
    from /home/travis/.rvm/gems/ruby-1.9.3-p551/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:10:in `require'
    from /home/travis/.rvm/gems/ruby-1.9.3-p551/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:10:in `block (2 levels) in <main>'
    from /home/travis/.rvm/gems/ruby-1.9.3-p551/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:9:in `each'
    from /home/travis/.rvm/gems/ruby-1.9.3-p551/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:9:in `block in <main>'
    from /home/travis/.rvm/gems/ruby-1.9.3-p551/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:4:in `select'
    from /home/travis/.rvm/gems/ruby-1.9.3-p551/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:4:in `<main>'
```
